### PR TITLE
Bump derive_more dependency to 1.0.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,6 @@ rust-version = "1.74.0"
 malachite = "<=0.4.18"
 num-traits = { version = "0.2.11", default-features = false, features = ["i128"] }
 num-integer = { version = "0.1.45", default-features = false, features = ["i128"] }
-derive_more = "0.99.17"
+derive_more = { version = "1.0.0", features = ["display", "from", "into"] }
 paste = "1.0.12"
 num-bigint = { version = "0.4", default-features = false, optional = true }

--- a/src/bigint.rs
+++ b/src/bigint.rs
@@ -18,6 +18,7 @@ use num_traits::{
 use paste::paste;
 use std::{
     cmp::Ordering,
+    fmt::Debug,
     iter::{Product, Sum},
     ops::{
         Add, AddAssign, BitAnd, BitAndAssign, BitOr, BitOrAssign, BitXor, BitXorAssign, Div,
@@ -78,7 +79,7 @@ impl Neg for Sign {
     From,
     Into,
 )]
-#[display(fmt = "{}", "self.0")]
+#[display("{}", "self.0")]
 #[into(owned, ref, ref_mut)]
 pub struct BigInt(Integer);
 
@@ -139,7 +140,7 @@ impl_sum_iter_type!(BigInt);
 
 impl std::fmt::Debug for BigInt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        self.0.fmt(f)
+        Debug::fmt(&self.0, f)
     }
 }
 

--- a/src/biguint.rs
+++ b/src/biguint.rs
@@ -18,6 +18,7 @@ use num_traits::{
 use paste::paste;
 use std::{
     cmp::Ordering::{Equal, Greater, Less},
+    fmt::Debug,
     iter::{Product, Sum},
     ops::{
         Add, AddAssign, BitAnd, BitAndAssign, BitOr, BitOrAssign, BitXor, BitXorAssign, Div,
@@ -53,7 +54,7 @@ impl_primitive_convert!(BigUint, f64);
     From,
     Into,
 )]
-#[display(fmt = "{}", "self.0")]
+#[display("{}", "self.0")]
 #[into(owned, ref, ref_mut)]
 pub struct BigUint(pub(crate) Natural);
 
@@ -112,7 +113,7 @@ impl_sum_iter_type!(BigUint);
 
 impl std::fmt::Debug for BigUint {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        self.0.fmt(f)
+        Debug::fmt(&self.0, f)
     }
 }
 


### PR DESCRIPTION
derive-more 1.0.0 turns off all features by default and allows picking only the ones you need. `malachite-bigint` only needs `display`, `from` and `into`.